### PR TITLE
Improve color space mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,4 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+/Consol3.exe

--- a/Consol3.vcxproj
+++ b/Consol3.vcxproj
@@ -151,26 +151,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -194,15 +194,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/CppProperties.json
+++ b/CppProperties.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "name": "x64-Debug",
+      "includePath": [
+        "${env.INCLUDE}",
+        "${workspaceRoot}\\**"
+      ],
+      "defines": [
+        "WIN32",
+        "_DEBUG",
+        "UNICODE",
+        "_UNICODE"
+      ],
+      "intelliSenseMode": "windows-msvc-x64"
+    }
+  ]
+}

--- a/src/Consol3.cpp
+++ b/src/Consol3.cpp
@@ -23,12 +23,13 @@ int main()
 
 	std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer = std::make_shared<FrameBuffer<CHAR_INFO>>(FrameBuffer<CHAR_INFO>(width, height));
 	// std::shared_ptr<FrameBuffer<RGBColor>> framebuffer = std::make_shared<FrameBuffer<RGBColor>>(width, height);
-	// std::shared_ptr<GreyscaleRenderer> renderer = std::make_shared<GreyscaleRenderer>(framebuffer);
-		std::shared_ptr<DitheredRenderer> renderer = std::make_shared<DitheredRenderer>(framebuffer);
-	//std::shared_ptr<DitheredGreyscaleRenderer> renderer = std::make_shared<DitheredGreyscaleRenderer>(framebuffer);
-	// std::shared_ptr<ANSIRenderer> renderer = std::make_shared<ANSIRenderer>(framebuffer);
 
+	// std::shared_ptr<GreyscaleRenderer> renderer = std::make_shared<GreyscaleRenderer>(framebuffer);
+	// std::shared_ptr<DitheredRenderer> renderer = std::make_shared<DitheredRenderer>(framebuffer);
+	std::shared_ptr<DitheredGreyscaleRenderer> renderer = std::make_shared<DitheredGreyscaleRenderer>(framebuffer);
 	// std::shared_ptr<TextOnlyRenderer> renderer = std::make_shared<TextOnlyRenderer>(framebuffer);
+
+	// std::shared_ptr<ANSIRenderer> renderer = std::make_shared<ANSIRenderer>(framebuffer);
 
 	Consol3Engine engine = Consol3Engine(renderer);
 

--- a/src/Consol3.cpp
+++ b/src/Consol3.cpp
@@ -24,8 +24,8 @@ int main()
 	std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer = std::make_shared<FrameBuffer<CHAR_INFO>>(FrameBuffer<CHAR_INFO>(width, height));
 	// std::shared_ptr<FrameBuffer<RGBColor>> framebuffer = std::make_shared<FrameBuffer<RGBColor>>(width, height);
 	// std::shared_ptr<GreyscaleRenderer> renderer = std::make_shared<GreyscaleRenderer>(framebuffer);
-	//	std::shared_ptr<DitheredRenderer> renderer = std::make_shared<DitheredRenderer>(framebuffer);
-	std::shared_ptr<DitheredGreyscaleRenderer> renderer = std::make_shared<DitheredGreyscaleRenderer>(framebuffer);
+		std::shared_ptr<DitheredRenderer> renderer = std::make_shared<DitheredRenderer>(framebuffer);
+	//std::shared_ptr<DitheredGreyscaleRenderer> renderer = std::make_shared<DitheredGreyscaleRenderer>(framebuffer);
 	// std::shared_ptr<ANSIRenderer> renderer = std::make_shared<ANSIRenderer>(framebuffer);
 
 	// std::shared_ptr<TextOnlyRenderer> renderer = std::make_shared<TextOnlyRenderer>(framebuffer);

--- a/src/Consol3.cpp
+++ b/src/Consol3.cpp
@@ -21,15 +21,15 @@ int main()
 	uint16_t width	= 200;
 	uint16_t height = 200;
 
-	std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer = std::make_shared<FrameBuffer<CHAR_INFO>>(FrameBuffer<CHAR_INFO>(width, height));
-	// std::shared_ptr<FrameBuffer<RGBColor>> framebuffer = std::make_shared<FrameBuffer<RGBColor>>(width, height);
+	// std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer = std::make_shared<FrameBuffer<CHAR_INFO>>(FrameBuffer<CHAR_INFO>(width, height));
+	std::shared_ptr<FrameBuffer<uint32_t>> framebuffer = std::make_shared<FrameBuffer<uint32_t>>(width, height);
 
 	// std::shared_ptr<GreyscaleRenderer> renderer = std::make_shared<GreyscaleRenderer>(framebuffer);
 	// std::shared_ptr<DitheredRenderer> renderer = std::make_shared<DitheredRenderer>(framebuffer);
-	std::shared_ptr<DitheredGreyscaleRenderer> renderer = std::make_shared<DitheredGreyscaleRenderer>(framebuffer);
+	// std::shared_ptr<DitheredGreyscaleRenderer> renderer = std::make_shared<DitheredGreyscaleRenderer>(framebuffer);
 	// std::shared_ptr<TextOnlyRenderer> renderer = std::make_shared<TextOnlyRenderer>(framebuffer);
 
-	// std::shared_ptr<ANSIRenderer> renderer = std::make_shared<ANSIRenderer>(framebuffer);
+	std::shared_ptr<ANSIRenderer> renderer = std::make_shared<ANSIRenderer>(framebuffer);
 
 	Consol3Engine engine = Consol3Engine(renderer);
 
@@ -37,5 +37,6 @@ int main()
 
 	// char a;
 	// scanf_s("%c", &a, 1);
+
 	return 0;
 }

--- a/src/Display/ANSIRenderer.cpp
+++ b/src/Display/ANSIRenderer.cpp
@@ -16,15 +16,9 @@ namespace Display
 		CreateFrameBufferString();
 	}
 
-	void ANSIRenderer::SetPixel(uint16_t x, uint16_t y, const HSVColor& color)
+	void ANSIRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		// TODO: Calculate the rgb value from the HSVColor
-		// or... refactor so we can make the engine output whatever we want (hsv or rgb) - the main issue here is how the IRenderer interface would
-		// look like
-		if (color.value != 0)
-			framebuffer->SetValue(x, y, RGBColor(255, 255, 255));
-		else
-			framebuffer->SetValue(x, y, RGBColor());
+		framebuffer->SetValue(x, y, color);
 	}
 
 	void ANSIRenderer::CreateFrameBufferString()

--- a/src/Display/ANSIRenderer.cpp
+++ b/src/Display/ANSIRenderer.cpp
@@ -1,71 +1,80 @@
 #include "ANSIRenderer.hpp"
 
-#define PIXEL_SIZE_CHARS   20	 // how many chars each pixel takes on the framebuffer_string
-#define PIXEL_RED_OFFSET   7	 // how many chars away from the start of the pixel string the component is at
-#define PIXEL_GREEN_OFFSET 11	 // ^
-#define PIXEL_BLUE_OFFSET  15	 // ^
-
 namespace Display
 {
-	ANSIRenderer::ANSIRenderer(std::shared_ptr<FrameBuffer<RGBColor>> framebuffer) :
+	ANSIRenderer::ANSIRenderer(std::shared_ptr<FrameBuffer<uint32_t>> framebuffer) :
 		framebuffer(std::move(framebuffer)),
-		console_manager(ConsoleManager(this->framebuffer->GetWidth(), this->framebuffer->GetHeight(), L"Consolas", 8, 8, palette_ansi))
+		console_manager(ConsoleManager(this->framebuffer->GetWidth(), this->framebuffer->GetHeight(), L"Consolas", 4, 4, palette_ansi))
 	{
 		ClearFrameBuffer();
-		framebuffer_string = std::shared_ptr<std::string>(new std::string());
-		CreateFrameBufferString();
+
+		framebuffer_string	   = std::string(this->framebuffer->GetWidth() * this->framebuffer->GetHeight() * 20, ' ');
+		framebuffer_string_len = 0;
 	}
 
 	void ANSIRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		framebuffer->SetValue(x, y, color);
-	}
-
-	void ANSIRenderer::CreateFrameBufferString()
-	{
-		// create the stringified framebuffer with all black pixels
-		for (uint16_t y = 0; y < framebuffer->GetHeight(); y++)
-		{
-			for (uint16_t x = 0; x < framebuffer->GetWidth(); x++)
-				framebuffer_string->append("\x1b[48;2;000;000;000m ");
-		}
+		framebuffer->SetValue(x, y, color.GetHexValues());
 	}
 
 	void ANSIRenderer::TranslateFrameBuffer()
 	{
-		char* string_data = framebuffer_string->data();
+		uint32_t last_color			  = 0x000000;
+		uint64_t current_string_index = 0;
 
 		for (uint16_t y = 0; y < framebuffer->GetHeight(); y++)
 		{
 			for (uint16_t x = 0; x < framebuffer->GetWidth(); x++)
 			{
-				const RGBColor& color = framebuffer->GetValue(x, y);
+				uint32_t current_color = framebuffer->GetValue(x, y);
 
-				std::string red_string = std::to_string(color.r);
-				red_string			   = std::string(3 - red_string.length(), '0') + red_string;
+				// always set color on the first pixel
+				if (current_color != last_color || (y == 0 && x == 0))
+				{
+					RGBColor rgbcurrent_color = RGBColor(current_color);
 
-				std::string green_string = std::to_string(color.g);
-				green_string			 = std::string(3 - green_string.length(), '0') + green_string;
+					std::string red_string = std::to_string(rgbcurrent_color.r) + ";";
+					uint8_t red_string_len = (uint8_t)red_string.length();
 
-				std::string blue_string = std::to_string(color.b);
-				blue_string				= std::string(3 - blue_string.length(), '0') + blue_string;
+					std::string green_string = std::to_string(rgbcurrent_color.g) + ";";
+					uint8_t green_string_len = (uint8_t)green_string.length();
 
-				uint32_t base_offset  = (x * PIXEL_SIZE_CHARS) + (y * PIXEL_SIZE_CHARS * framebuffer->GetWidth());
-				uint32_t red_offset	  = base_offset + PIXEL_RED_OFFSET;
-				uint32_t green_offset = base_offset + PIXEL_GREEN_OFFSET;
-				uint32_t blue_offset  = base_offset + PIXEL_BLUE_OFFSET;
+					std::string blue_string = std::to_string(rgbcurrent_color.b);
+					uint8_t blue_string_len = (uint8_t)blue_string.length();
 
-				red_string.copy(string_data + red_offset, 3);
-				green_string.copy(string_data + green_offset, 3);
-				blue_string.copy(string_data + blue_offset, 3);
+					esc_sequence_start.copy(framebuffer_string.data() + current_string_index, esc_sequence_start_len, 0);
+					current_string_index += esc_sequence_start_len;
+
+					red_string.copy(framebuffer_string.data() + current_string_index, red_string_len, 0);
+					current_string_index += red_string_len;
+
+					green_string.copy(framebuffer_string.data() + current_string_index, green_string_len, 0);
+					current_string_index += green_string_len;
+
+					blue_string.copy(framebuffer_string.data() + current_string_index, blue_string_len, 0);
+					current_string_index += blue_string_len;
+
+					esc_sequence_end.copy(framebuffer_string.data() + current_string_index, esc_sequence_len, 0);
+					current_string_index += esc_sequence_len;
+
+					last_color = current_color;
+				}
+
+				framebuffer_string.data()[current_string_index++] = ' ';
 			}
+
+			framebuffer_string.data()[current_string_index++] = '\n';
 		}
+
+		framebuffer_string.data()[current_string_index++] = '\0';
+
+		framebuffer_string_len = current_string_index;
 	}
 
 	void ANSIRenderer::DisplayFrame()
 	{
 		TranslateFrameBuffer();
-		console_manager.WriteConsoleString(framebuffer_string, (uint32_t)framebuffer_string->length());
+		console_manager.WriteConsoleString(framebuffer_string, framebuffer_string_len);
 	}
 
 	void ANSIRenderer::ReportInformation(const std::string& info)
@@ -75,7 +84,7 @@ namespace Display
 
 	void ANSIRenderer::ClearFrameBuffer()
 	{
-		this->framebuffer->FillBuffer(RGBColor());
+		this->framebuffer->FillBuffer(0x000000);
 	}
 
 	const uint16_t ANSIRenderer::GetFrameBufferWidth() const

--- a/src/Display/ANSIRenderer.hpp
+++ b/src/Display/ANSIRenderer.hpp
@@ -34,7 +34,7 @@ namespace Display
 	public:
 		ANSIRenderer(std::shared_ptr<FrameBuffer<RGBColor>> framebuffer);
 
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) override;
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override;
 
 		virtual void DisplayFrame() override;
 

--- a/src/Display/ANSIRenderer.hpp
+++ b/src/Display/ANSIRenderer.hpp
@@ -1,3 +1,5 @@
+
+
 #ifndef ANSIRENDERER_HPP
 #define ANSIRENDERER_HPP
 
@@ -12,6 +14,7 @@
 #include <Windows.h>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 namespace Display
 {
@@ -23,16 +26,21 @@ namespace Display
 	class ANSIRenderer : public IRenderer
 	{
 	private:
-		std::shared_ptr<FrameBuffer<RGBColor>> framebuffer;
+		std::shared_ptr<FrameBuffer<uint32_t>> framebuffer;
 		ConsoleManager console_manager;
 
-		std::shared_ptr<std::string> framebuffer_string;
+		std::string framebuffer_string;
+		uint64_t framebuffer_string_len;
 
-		void CreateFrameBufferString();
+		const std::string esc_sequence_start = "\x1b[48;2;";
+		const uint8_t esc_sequence_start_len = (uint8_t)esc_sequence_start.length();
+		const std::string esc_sequence_end	 = "m";
+		const uint8_t esc_sequence_len		 = (uint8_t)esc_sequence_end.length();
+
 		void TranslateFrameBuffer();
 
 	public:
-		ANSIRenderer(std::shared_ptr<FrameBuffer<RGBColor>> framebuffer);
+		ANSIRenderer(std::shared_ptr<FrameBuffer<uint32_t>> framebuffer);
 
 		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override;
 

--- a/src/Display/ConsoleManager.cpp
+++ b/src/Display/ConsoleManager.cpp
@@ -24,6 +24,7 @@ namespace Display
 		SetFontInfo(font_name, font_width, font_height, 0, 0);
 
 		DisableCursor();
+		// SetConsoleMode(consolescreenbuffer, ENABLE_WRAP_AT_EOL_OUTPUT);
 	}
 
 	ConsoleManager::~ConsoleManager()
@@ -42,7 +43,7 @@ namespace Display
 		// struct
 		info.cbSize = sizeof(CONSOLE_SCREEN_BUFFER_INFOEX);
 		// resolution, how many chars there are
-		info.dwSize = { width, height };	// the +1 avoids problems when resizing
+		info.dwSize = { width, height + 1 };	// the +1 avoids problems when resizing
 		// position of the cursor (irrelevant since we're going to hide it)
 		info.dwCursorPosition = { 0, 0 };
 		// attributes used by preceding writes (irrelevant since we're not going to give input to the console)
@@ -152,12 +153,15 @@ namespace Display
 							&writeregion);			// region to write to
 	}
 
-	void ConsoleManager::WriteConsoleString(const std::shared_ptr<std::string> string, uint32_t size)
+	void ConsoleManager::WriteConsoleString(const std::string& string, uint64_t size)
 	{
 		DWORD written_count;
 
 		SetConsoleCursorPosition(consolescreenbuffer, { 0, 0 });
 
-		WriteConsoleA(consolescreenbuffer, string->c_str(), size, &written_count, nullptr);
+		char arr[] = "AA\x1b[48;2;255;000;000mAA\x1b[48;2;000;255;000mAA";
+		// string->data()[36] = '\0';
+		// WriteConsoleA(consolescreenbuffer, arr, 46, &written_count, nullptr);
+		WriteConsoleA(consolescreenbuffer, string.c_str(), (DWORD)size, &written_count, nullptr);
 	}
 }

--- a/src/Display/ConsoleManager.cpp
+++ b/src/Display/ConsoleManager.cpp
@@ -159,9 +159,6 @@ namespace Display
 
 		SetConsoleCursorPosition(consolescreenbuffer, { 0, 0 });
 
-		char arr[] = "AA\x1b[48;2;255;000;000mAA\x1b[48;2;000;255;000mAA";
-		// string->data()[36] = '\0';
-		// WriteConsoleA(consolescreenbuffer, arr, 46, &written_count, nullptr);
-		WriteConsoleA(consolescreenbuffer, string.c_str(), (DWORD)size, &written_count, nullptr);
+		WriteFile(consolescreenbuffer, string.c_str(), (DWORD)size, &written_count, nullptr);
 	}
 }

--- a/src/Display/ConsoleManager.hpp
+++ b/src/Display/ConsoleManager.hpp
@@ -48,7 +48,7 @@ namespace Display
 		void SetTitle(const std::string& title);
 
 		void FillScreenBuffer(const CHAR_INFO* data);
-		void WriteConsoleString(const std::shared_ptr<std::string> string, uint32_t size);
+		void WriteConsoleString(const std::string& string, uint64_t size);
 	};
 }
 

--- a/src/Display/DitheredGreyscaleRenderer.cpp
+++ b/src/Display/DitheredGreyscaleRenderer.cpp
@@ -78,9 +78,11 @@ namespace Display
 		}
 	}
 
-	void DitheredGreyscaleRenderer::SetPixel(uint16_t x, uint16_t y, const HSVColor& color)
+	void DitheredGreyscaleRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		uint8_t shade = Util::LerpCast<uint8_t>(color.value, 0, 255);
+		float luminance = color.GetLuminance();
+
+		uint8_t shade = Util::LerpCast<uint8_t>(luminance, 0, 255);
 		framebuffer->SetValue(x, y, shade_map[shade]);
 	}
 

--- a/src/Display/DitheredGreyscaleRenderer.cpp
+++ b/src/Display/DitheredGreyscaleRenderer.cpp
@@ -80,7 +80,7 @@ namespace Display
 
 	void DitheredGreyscaleRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		float luminance = color.GetLuminance();
+		float luminance = color.GetColorNormal();
 
 		uint8_t shade = Util::LerpCast<uint8_t>(luminance, 0, 255);
 		framebuffer->SetValue(x, y, shade_map[shade]);

--- a/src/Display/DitheredGreyscaleRenderer.hpp
+++ b/src/Display/DitheredGreyscaleRenderer.hpp
@@ -41,7 +41,7 @@ namespace Display
 	public:
 		DitheredGreyscaleRenderer(std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer);
 
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) override;
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override;
 
 		virtual void DisplayFrame() override;
 

--- a/src/Display/DitheredRenderer.cpp
+++ b/src/Display/DitheredRenderer.cpp
@@ -13,12 +13,14 @@ namespace Display
 		ClearFrameBuffer();
 	}
 
-	void DitheredRenderer::SetPixel(uint16_t x, uint16_t y, const HSVColor& color)
+	void DitheredRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
+		HSVColor hsvcolor = HSVColor(color);
+
 		// white/black
-		if (color.saturation <= 0.25f)
+		if (hsvcolor.saturation <= 0.25f)
 		{
-			uint8_t shade_index = Util::LerpCast<uint8_t>(color.value, 0, 15);
+			uint8_t shade_index = Util::LerpCast<uint8_t>(hsvcolor.value, 0, 15);
 
 			framebuffer->SetValue(x, y, dithered_white[shade_index]);
 			return;
@@ -26,16 +28,16 @@ namespace Display
 
 		// TODO: this shouldn't be a linear interpolation as the shade_indexes are not linear
 		// the shade amount should be pre calculated and this should be made into a binary search
-		uint8_t shade_index = Util::LerpCast<uint8_t>(color.value, 0, 10);
+		uint8_t shade_index = Util::LerpCast<uint8_t>(hsvcolor.value, 0, 10);
 
 		// special red case because it wraps over the 360 mark
-		if (color.hue >= dithered_red.min_hue || color.hue <= dithered_red.max_hue)
+		if (hsvcolor.hue >= dithered_red.min_hue || hsvcolor.hue <= dithered_red.max_hue)
 			framebuffer->SetValue(x, y, dithered_red.color_shades[shade_index]);
 
 		// select color by hue
 		for (const DitheredColor& dithered_color : sequential_dithered_colors)
 		{
-			if (dithered_color.min_hue <= color.hue && color.hue <= dithered_color.max_hue)
+			if (dithered_color.min_hue <= hsvcolor.hue && hsvcolor.hue <= dithered_color.max_hue)
 			{
 				framebuffer->SetValue(x, y, dithered_color.color_shades[shade_index]);
 				break;

--- a/src/Display/DitheredRenderer.hpp
+++ b/src/Display/DitheredRenderer.hpp
@@ -158,7 +158,7 @@ namespace Display
 	public:
 		DitheredRenderer(std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer);
 
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) override;
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override;
 
 		virtual void DisplayFrame() override;
 

--- a/src/Display/GreyscaleRenderer.cpp
+++ b/src/Display/GreyscaleRenderer.cpp
@@ -10,10 +10,12 @@ namespace Display
 		ClearFrameBuffer();
 	}
 
-	void GreyscaleRenderer::SetPixel(uint16_t x, uint16_t y, const HSVColor& color)
+	void GreyscaleRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
+		float luminance = color.GetLuminance();
+
 		// map it to a 0-15 palette index
-		uint8_t index			 = 16 + (uint8_t)((15.0f * color.value));
+		uint8_t index			 = 16 + (uint8_t)((15.0f * luminance));
 		uint8_t background_index = index * 16;
 
 		// in greyscale all pixels are a space and we control the color through the background

--- a/src/Display/GreyscaleRenderer.cpp
+++ b/src/Display/GreyscaleRenderer.cpp
@@ -12,7 +12,7 @@ namespace Display
 
 	void GreyscaleRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		float luminance = color.GetLuminance();
+		float luminance = color.GetColorNormal();
 
 		// map it to a 0-15 palette index
 		uint8_t index			 = 16 + (uint8_t)((15.0f * luminance));

--- a/src/Display/GreyscaleRenderer.hpp
+++ b/src/Display/GreyscaleRenderer.hpp
@@ -26,7 +26,7 @@ namespace Display
 	public:
 		GreyscaleRenderer(std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer);
 
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) override;
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override;
 
 		virtual void DisplayFrame() override;
 

--- a/src/Display/IRenderer.hpp
+++ b/src/Display/IRenderer.hpp
@@ -18,7 +18,7 @@ namespace Display
 		}
 
 	public:
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) = 0;
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) = 0;
 
 		virtual void ClearFrameBuffer() = 0;
 		virtual void DisplayFrame()		= 0;

--- a/src/Display/NullRenderer.hpp
+++ b/src/Display/NullRenderer.hpp
@@ -18,7 +18,7 @@ namespace Display
 		{
 		}
 
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) override
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override
 		{
 		}
 

--- a/src/Display/RGBColor.hpp
+++ b/src/Display/RGBColor.hpp
@@ -61,9 +61,23 @@ namespace Display
 			return *this;
 		}
 
+		constexpr RGBColor& BlendMultiply(float value)
+		{
+			r = (uint8_t)((r * (uint8_t)(255 * value) + 0xFF) >> 8);
+			g = (uint8_t)((g * (uint8_t)(255 * value) + 0xFF) >> 8);
+			b = (uint8_t)((b * (uint8_t)(255 * value) + 0xFF) >> 8);
+
+			return *this;
+		}
+
 		constexpr RGBColor GetBlendMultiplied(RGBColor other)
 		{
 			return RGBColor(*this).BlendMultiply(other);
+		}
+
+		constexpr RGBColor GetBlendMultiplied(float value)
+		{
+			return RGBColor(*this).BlendMultiply(value);
 		}
 	};
 }

--- a/src/Display/RGBColor.hpp
+++ b/src/Display/RGBColor.hpp
@@ -39,7 +39,7 @@ namespace Display
 		/**
 		 * Returns a 0-255 float value representing the lightness of the color based on luminosity
 		 */
-		[[nodiscard]] inline constexpr float ToGreyscale()
+		[[nodiscard]] inline constexpr float GetGreyscale() const
 		{
 			return 0.3f * r + 0.59f * g + 0.11f * b;
 		}
@@ -47,12 +47,13 @@ namespace Display
 		/**
 		 * Returns a 0-255 float value representing the brightness of the color based on luminosity
 		 */
-		[[nodiscard]] static inline constexpr float HexToGreyscale(uint32_t color)
+		[[nodiscard]] static inline constexpr float GetGreyscaleFromHex(uint32_t color)
 		{
 			return 0.3f * (color >> 16) + 0.59f * (color >> 8 & 0xFF) + 0.11f * (color & 0xFF);
 		}
 
-		[[nodiscard]] inline constexpr float GetLuminance()
+		// avoids converting to HSV to get the value
+		[[nodiscard]] inline constexpr float GetColorNormal() const
 		{
 			return ((r + g + b) / 3.0f) / 255.0f;
 		}

--- a/src/Display/RGBColor.hpp
+++ b/src/Display/RGBColor.hpp
@@ -52,6 +52,11 @@ namespace Display
 			return 0.3f * (color >> 16) + 0.59f * (color >> 8 & 0xFF) + 0.11f * (color & 0xFF);
 		}
 
+		[[nodiscard]] inline constexpr float GetLuminance()
+		{
+			return ((r + g + b) / 3.0f) / 255.0f;
+		}
+
 		constexpr RGBColor& BlendMultiply(RGBColor other)
 		{
 			r = (uint8_t)((r * other.r + 0xFF) >> 8);
@@ -70,12 +75,12 @@ namespace Display
 			return *this;
 		}
 
-		constexpr RGBColor GetBlendMultiplied(RGBColor other)
+		[[nodiscard]] constexpr RGBColor GetBlendMultiplied(RGBColor other)
 		{
 			return RGBColor(*this).BlendMultiply(other);
 		}
 
-		constexpr RGBColor GetBlendMultiplied(float value)
+		[[nodiscard]] constexpr RGBColor GetBlendMultiplied(float value)
 		{
 			return RGBColor(*this).BlendMultiply(value);
 		}

--- a/src/Display/TextOnlyRenderer.cpp
+++ b/src/Display/TextOnlyRenderer.cpp
@@ -14,9 +14,11 @@ namespace Display
 		ClearFrameBuffer();
 	}
 
-	void TextOnlyRenderer::SetPixel(uint16_t x, uint16_t y, const HSVColor& color)
+	void TextOnlyRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		uint8_t index = Math::Util::LerpCast<uint8_t>(color.value, 0, shades_count - 1);
+		float luminance = color.GetLuminance();
+
+		uint8_t index = Math::Util::LerpCast<uint8_t>(luminance, 0, shades_count - 1);
 
 		framebuffer->SetValue(x, y, { (WCHAR)shades[index], 0x0F });
 	}

--- a/src/Display/TextOnlyRenderer.cpp
+++ b/src/Display/TextOnlyRenderer.cpp
@@ -16,7 +16,7 @@ namespace Display
 
 	void TextOnlyRenderer::SetPixel(uint16_t x, uint16_t y, RGBColor color)
 	{
-		float luminance = color.GetLuminance();
+		float luminance = color.GetColorNormal();
 
 		uint8_t index = Math::Util::LerpCast<uint8_t>(luminance, 0, shades_count - 1);
 

--- a/src/Display/TextOnlyRenderer.hpp
+++ b/src/Display/TextOnlyRenderer.hpp
@@ -30,7 +30,7 @@ namespace Display
 	public:
 		TextOnlyRenderer(std::shared_ptr<FrameBuffer<CHAR_INFO>> framebuffer);
 
-		virtual void SetPixel(uint16_t x, uint16_t y, const HSVColor& color) override;
+		virtual void SetPixel(uint16_t x, uint16_t y, RGBColor color) override;
 
 		virtual void DisplayFrame() override;
 

--- a/src/Engine/Consol3Engine.cpp
+++ b/src/Engine/Consol3Engine.cpp
@@ -94,10 +94,11 @@ namespace Engine
 
 	inline void Consol3Engine::DrawFrame(int64_t delta)
 	{
+		auto time = this->GetCurrentTime();
 		renderer->ClearFrameBuffer();
-
-		renderer->ReportInformation(std::string("Consol3 - draw time: ") + std::to_string(game.Render(delta).count()));
-
+		game.Render(delta);
 		renderer->DisplayFrame();
+
+		renderer->ReportInformation(std::string("Consol3 - draw time: ") + std::to_string(this->GetCurrentTime() - time));
 	}
 }

--- a/src/Engine/Rendering/Rasterizer.cpp
+++ b/src/Engine/Rendering/Rasterizer.cpp
@@ -149,7 +149,7 @@ namespace Engine
 
 						if (depthbuffer.GetValue(x, y) > z)
 						{
-							HSVColor out_color = shader.FragmentShader(color, triangle, barcoord0, barcoord1, barcoord2);
+							RGBColor out_color = shader.FragmentShader(color, triangle, barcoord0, barcoord1, barcoord2);
 
 							depthbuffer.SetValue(x, y, z);
 							renderer->SetPixel(x, y, out_color);

--- a/src/Engine/Rendering/Shaders/DepthMapShader.cpp
+++ b/src/Engine/Rendering/Shaders/DepthMapShader.cpp
@@ -15,10 +15,9 @@ namespace Engine
 				return true;	// IsBackface(v0.GetPosition(), v1.GetPosition(), v2.GetPosition());
 			}
 
-			HSVColor DepthMapShader::FragmentShader(
-				const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
+			RGBColor DepthMapShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
 			{
-				return HSVColor();
+				return RGBColor();
 			}
 		}
 	}

--- a/src/Engine/Rendering/Shaders/DepthMapShader.hpp
+++ b/src/Engine/Rendering/Shaders/DepthMapShader.hpp
@@ -3,7 +3,6 @@
 
 #include "IShader.hpp"
 
-#include "../../../Display/HSVColor.hpp"
 #include "../../../Display/RGBColor.hpp"
 #include "../../../Math/Matrix4.hpp"
 #include "../Vertex.hpp"
@@ -21,8 +20,7 @@ namespace Engine
 			private:
 			public:
 				virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) override;
-				virtual HSVColor FragmentShader(
-					const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
+				virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
 			};
 
 		}

--- a/src/Engine/Rendering/Shaders/IShader.hpp
+++ b/src/Engine/Rendering/Shaders/IShader.hpp
@@ -1,7 +1,7 @@
 #ifndef ISHADER_HPP
 #define ISHADER_HPP
 
-#include "../../../Display/HSVColor.hpp"
+#include "../../../Display/RGBColor.hpp"
 #include "../../../Math/Matrix4.hpp"
 #include "../Triangle.hpp"
 #include "../Vertex.hpp"
@@ -95,9 +95,8 @@ namespace Engine
 				}
 
 			public:
-				virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) = 0;
-				virtual HSVColor FragmentShader(
-					const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) = 0;
+				virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats)									 = 0;
+				virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) = 0;
 			};
 		}
 	}

--- a/src/Engine/Rendering/Shaders/PlainShader.cpp
+++ b/src/Engine/Rendering/Shaders/PlainShader.cpp
@@ -24,7 +24,7 @@ namespace Engine
 				return !IsBackface(v0.GetPosition(), v1.GetPosition(), v2.GetPosition());
 			}
 
-			HSVColor PlainShader::FragmentShader(const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
+			RGBColor PlainShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
 			{
 				Vector2 frag_texture_coord = PerspectiveCorrectInterpolate<Vector2>(vert_v0_texture_coord,
 																					vert_v1_texture_coord,
@@ -34,9 +34,10 @@ namespace Engine
 																					barcoord1,
 																					barcoord2);
 
-				RGBColor texture_color = texture->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
+				RGBColor final_color = texture->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
+				final_color.BlendMultiply(color);
 
-				return HSVColor(texture_color.BlendMultiply(color));
+				return final_color;
 			}
 		}
 	}

--- a/src/Engine/Rendering/Shaders/PlainShader.hpp
+++ b/src/Engine/Rendering/Shaders/PlainShader.hpp
@@ -3,7 +3,6 @@
 
 #include "IShader.hpp"
 
-#include "../../../Display/HSVColor.hpp"
 #include "../../../Display/RGBColor.hpp"
 #include "../../../Math/Matrix4.hpp"
 #include "../Texture.hpp"
@@ -29,8 +28,7 @@ namespace Engine
 
 			public:
 				virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) override;
-				virtual HSVColor FragmentShader(
-					const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
+				virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
 
 				void SetTexture(std::shared_ptr<Texture> texture);
 			};

--- a/src/Engine/Rendering/Shaders/ShadedShader.cpp
+++ b/src/Engine/Rendering/Shaders/ShadedShader.cpp
@@ -174,9 +174,11 @@ namespace Engine
 
 				RGBColor texture_color = texture->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
 				texture_color.BlendMultiply(color);
+				texture_color.BlendMultiply(final_lighting);
+
 				HSVColor color_hsv = HSVColor(texture_color);
 
-				return HSVColor(color_hsv.hue, color_hsv.saturation, color_hsv.value * final_lighting);
+				return color_hsv;
 			}
 		}
 	}

--- a/src/Engine/Rendering/Shaders/ShadedShader.cpp
+++ b/src/Engine/Rendering/Shaders/ShadedShader.cpp
@@ -92,7 +92,7 @@ namespace Engine
 				return !IsBackface(v0.GetPosition(), v1.GetPosition(), v2.GetPosition());
 			}
 
-			HSVColor ShadedShader::FragmentShader(const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
+			RGBColor ShadedShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
 			{
 				Vector3 frag_position = PerspectiveCorrectInterpolate<Vector3>(vert_v0_model.GetPosition(),
 																			   vert_v1_model.GetPosition(),
@@ -172,13 +172,12 @@ namespace Engine
 					lighting_system->GetLightAmountAt(frag_position, frag_normal, camera_position, frag_position_lights, material_properties);
 				float final_lighting = std::min(lighting_system->GetAmbientLight() + light_amount, 1.0f);
 
-				RGBColor texture_color = texture->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
-				texture_color.BlendMultiply(color);
-				texture_color.BlendMultiply(final_lighting);
+				RGBColor final_color = texture->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
 
-				HSVColor color_hsv = HSVColor(texture_color);
+				final_color.BlendMultiply(color);
+				final_color.BlendMultiply(final_lighting);
 
-				return color_hsv;
+				return final_color;
 			}
 		}
 	}

--- a/src/Engine/Rendering/Shaders/ShadedShader.hpp
+++ b/src/Engine/Rendering/Shaders/ShadedShader.hpp
@@ -3,7 +3,6 @@
 
 #include "IShader.hpp"
 
-#include "../../../Display/HSVColor.hpp"
 #include "../../../Display/RGBColor.hpp"
 #include "../../../Math/Matrix4.hpp"
 #include "../DepthBuffer.hpp"
@@ -58,8 +57,7 @@ namespace Engine
 
 			public:
 				virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) override;
-				virtual HSVColor FragmentShader(
-					const RGBColor& color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
+				virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
 
 				void SetLightingSystem(std::shared_ptr<LightingSystem> lighting_system);
 

--- a/src/Game/Consol3Game.cpp
+++ b/src/Game/Consol3Game.cpp
@@ -77,6 +77,7 @@ namespace Game
 		mesh2 = StaticMesh();
 		mesh2.SetModelResource("res/bunny.obj")
 			.SetPosition(Vector3(-2, 1, 0))
+			.SetColor(RGBColor(255, 0, 0))
 			.SetRotation(Angle(0, 3.14159f / 2 * 4, 0))
 			.SetScale(Vector3(10.0f, 10.0f, 10.0f))
 			.SetMaterialProperties(MaterialProperties(0.0f, 0.0f));
@@ -99,10 +100,10 @@ namespace Game
 		spot_light->SetAngle(20.0f);
 		spot_light->SetIntensity(6.0f);
 
-		this->lighting_system->SetAmbientLight(0.02f);
+		this->lighting_system->SetAmbientLight(0.12f);
 		// this->lighting_system->AddLight(dir_light);
-		this->lighting_system->AddLight(point_light);
-		// this->lighting_system->AddLight(spot_light);
+		// this->lighting_system->AddLight(point_light);
+		this->lighting_system->AddLight(spot_light);
 
 		plight_mesh.SetScale(Vector3(0.1f, 0.1f, 0.1f));
 	}
@@ -184,12 +185,12 @@ namespace Game
 			plight_mesh.SetPosition(camera->GetPosition());
 		}
 
-		if (GetKeyState(VK_RBUTTON) & 0X8000)
+		if (GetKeyState(VK_LBUTTON) & 0X8000)
 		{
 			spot_light->SetPosition(camera->GetPosition());
 			spot_light->SetDirection(camera->GetLookDirection());
 		}
-		if (GetKeyState(VK_LBUTTON) & 0X8000)
+		if (GetKeyState(VK_RBUTTON) & 0X8000)
 		{
 		}
 	}
@@ -209,10 +210,10 @@ namespace Game
 
 		scene_renderer->DrawShadedMesh(floor);
 
-		scene_renderer->DrawShadedMesh(mesh);
+		// scene_renderer->DrawShadedMesh(mesh);
 		scene_renderer->DrawShadedMesh(mesh2);
 
-		scene_renderer->DrawMesh(plight_mesh);
+		//	scene_renderer->DrawMesh(plight_mesh);
 
 		//	scene_renderer->DrawShadedMesh(anim_mesh);
 

--- a/src/Game/Consol3Game.cpp
+++ b/src/Game/Consol3Game.cpp
@@ -70,9 +70,10 @@ namespace Game
 		mesh = StaticMesh();
 		mesh.SetModelResource("res/bunny.obj")
 			.SetPosition(Vector3(2, 1, 0))
+			.SetColor(RGBColor(0, 0, 200))
 			.SetRotation(Angle(0, 3.14159f / 2 * 4, 0))
-			.SetScale(Vector3(10.0f, 10.0f, 10.0f))
-			.SetMaterialProperties(MaterialProperties(20.0f, 1.6f));
+			.SetScale(Vector3(10.0f, 10.0f, 10.0f));
+		//.SetMaterialProperties(MaterialProperties(20.0f, 1.6f));
 
 		mesh2 = StaticMesh();
 		mesh2.SetModelResource("res/bunny.obj")
@@ -210,7 +211,7 @@ namespace Game
 
 		scene_renderer->DrawShadedMesh(floor);
 
-		// scene_renderer->DrawShadedMesh(mesh);
+		scene_renderer->DrawMesh(mesh);
 		scene_renderer->DrawShadedMesh(mesh2);
 
 		//	scene_renderer->DrawMesh(plight_mesh);

--- a/src/Game/Consol3Game.cpp
+++ b/src/Game/Consol3Game.cpp
@@ -61,11 +61,31 @@ namespace Game
 		this->scene_renderer->SetCamera(camera);
 
 		anim_mesh = AnimatedMesh();
-		anim_mesh.SetModelResource("res/penguin.md2")
-			.SetTextureResource("res/penguin.bmp")
-			.SetPosition(Vector3(0.0f, -0.9f, 0.0f))
+		anim_mesh
+			.SetModelResource("res/marvin.md2")
+			//.SetTextureResource("res/text.bmp")
+			.SetPosition(Vector3(1.0f, -0.9f, 0.0f))
 			.SetScale(Vector3(0.05f, 0.05f, 0.05f))
-			.SetRotation(Angle(0, 3.14159f / 2 * 4, 0));
+			.SetRotation(Angle(-1.7, 0, 0))
+			.SetColor(RGBColor(255, 0, 0));
+
+		anim_mesh2 = AnimatedMesh();
+		anim_mesh2
+			.SetModelResource("res/marvin.md2")
+			//.SetTextureResource("res/text.bmp")
+			.SetPosition(Vector3(-1.0f, -0.9f, 0.0f))
+			.SetScale(Vector3(0.05f, 0.05f, 0.05f))
+			.SetRotation(Angle(-1.7, 0, 0))
+			.SetColor(RGBColor(0, 255, 0));
+
+		anim_mesh3 = AnimatedMesh();
+		anim_mesh3
+			.SetModelResource("res/marvin.md2")
+			//.SetTextureResource("res/text.bmp")
+			.SetPosition(Vector3(0.0f, -0.9f, 1.0f))
+			.SetScale(Vector3(0.05f, 0.05f, 0.05f))
+			.SetRotation(Angle(-1.7, 0, 0))
+			.SetColor(RGBColor(0, 0, 255));
 
 		mesh = StaticMesh();
 		mesh.SetModelResource("res/bunny.obj")
@@ -102,9 +122,9 @@ namespace Game
 		spot_light->SetIntensity(6.0f);
 
 		this->lighting_system->SetAmbientLight(0.12f);
-		// this->lighting_system->AddLight(dir_light);
+		this->lighting_system->AddLight(dir_light);
 		// this->lighting_system->AddLight(point_light);
-		this->lighting_system->AddLight(spot_light);
+		// this->lighting_system->AddLight(spot_light);
 
 		plight_mesh.SetScale(Vector3(0.1f, 0.1f, 0.1f));
 	}
@@ -201,6 +221,9 @@ namespace Game
 	{
 		// point_light->SetPosition(Vector3(std::sin(i) * 2, 0.5, std::cos(i) * 2));
 		// plight_mesh.SetPosition(Vector3(std::sin(i) * 2, 0.5, std::cos(i) * 2));
+		anim_mesh.SetPosition(Vector3(std::sin(i) * 2, -0.9f, std::cos(i) * 2));
+		anim_mesh2.SetPosition(Vector3(std::sin(i + 2) * 2, -0.9f, std::cos(i + 2) * 2));
+		anim_mesh3.SetPosition(Vector3(std::sin(i + 4) * 2, -0.9f, std::cos(i + 4) * 2));
 
 		i += 0.01f;
 	}
@@ -211,12 +234,14 @@ namespace Game
 
 		scene_renderer->DrawShadedMesh(floor);
 
-		scene_renderer->DrawMesh(mesh);
-		scene_renderer->DrawShadedMesh(mesh2);
+		// scene_renderer->DrawShadedMesh(mesh);
+		// scene_renderer->DrawShadedMesh(mesh2);
 
 		//	scene_renderer->DrawMesh(plight_mesh);
 
-		//	scene_renderer->DrawShadedMesh(anim_mesh);
+		scene_renderer->DrawShadedMesh(anim_mesh);
+		scene_renderer->DrawShadedMesh(anim_mesh2);
+		scene_renderer->DrawShadedMesh(anim_mesh3);
 
 		scene_renderer->RenderScene(delta);
 		/*

--- a/src/Game/Consol3Game.hpp
+++ b/src/Game/Consol3Game.hpp
@@ -43,8 +43,11 @@ namespace Game
 
 		StaticMesh mesh;
 		StaticMesh mesh2;
+		StaticMesh mesh3;
 
 		AnimatedMesh anim_mesh;
+		AnimatedMesh anim_mesh2;
+		AnimatedMesh anim_mesh3;
 		StaticMesh floor;
 
 		std::shared_ptr<DirectionalLight> dir_light;


### PR DESCRIPTION
- Removes dependency of HSV conversions from the fragment shader, becoming the console renderer's responsibility instead (if it needs it)
- Optimizes the ANSI renderer by only changing the color via escape sequences in the string if the color on the frame buffer changes (allowing for one escape sequence to affect multiple pixels)

With the optimized ANSI renderer that provides full 24 bit color, it has been noted that the main slowdown comes from the console itself when rendering consecutive characters in different colors (due to the way caching is done on the console code), and not from the color space translations in the renderers

There are more optimizations possible in the renderers like using the VT escape sequences for indexed colors instead of full RGB, using a lookup table for that etc, but I've decide not to pursue those optimizations since they would not matter overall due to the above points (the translation is already fast enough)


Closes #10 