### PR TITLE
Open the door for shader parallelization

### DIFF
--- a/src/Engine/Rendering/Rasterizer.hpp
+++ b/src/Engine/Rendering/Rasterizer.hpp
@@ -43,7 +43,7 @@ namespace Engine
             inline Vertex& TransformVertexScreenspace(Vertex& vertex);
 
             void ClipAndRasterize(DepthBuffer& depthbuffer, const VertexBuffer& vertex_buffer, const RGBColor& color, IShader& shader);
-            void RasterizeTriangle(DepthBuffer& depthbuffer, const Triangle& triangle, const RGBColor& color, IShader& shader);
+            void RasterizeTriangle(DepthBuffer& depthbuffer, const Triangle& triangle, const RGBColor& color, IShader& shader, const void* context);
 
         public:
             Rasterizer();

--- a/src/Engine/Rendering/Shaders/DepthMapShader.cpp
+++ b/src/Engine/Rendering/Shaders/DepthMapShader.cpp
@@ -6,7 +6,12 @@ namespace Engine
     {
         namespace Shaders
         {
-            bool DepthMapShader::VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats)
+            size_t DepthMapShader::GetFragmentContextSize() const
+            {
+                return 0;
+            }
+
+            bool DepthMapShader::VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context)
             {
                 TransformVertexMVP(v0, mvp_mats);
                 TransformVertexMVP(v1, mvp_mats);
@@ -15,7 +20,7 @@ namespace Engine
                 return true;    // IsBackface(v0.GetPosition(), v1.GetPosition(), v2.GetPosition());
             }
 
-            RGBColor DepthMapShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
+            RGBColor DepthMapShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2, const void* context)
             {
                 return RGBColor();
             }

--- a/src/Engine/Rendering/Shaders/DepthMapShader.hpp
+++ b/src/Engine/Rendering/Shaders/DepthMapShader.hpp
@@ -19,8 +19,9 @@ namespace Engine
             {
             private:
             public:
-                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) override;
-                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
+                virtual size_t GetFragmentContextSize() const override;
+                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context) override;
+                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2, const void* context) override;
             };
 
         }

--- a/src/Engine/Rendering/Shaders/IShader.hpp
+++ b/src/Engine/Rendering/Shaders/IShader.hpp
@@ -89,8 +89,9 @@ namespace Engine
                 }
 
             public:
-                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats)                                  = 0;
-                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) = 0;
+                virtual size_t GetFragmentContextSize() const                                                                                                     = 0;
+                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context)                                        = 0;
+                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2, const void* context) = 0;
             };
         }
     }

--- a/src/Engine/Rendering/Shaders/PlainShader.cpp
+++ b/src/Engine/Rendering/Shaders/PlainShader.cpp
@@ -1,5 +1,16 @@
 #include "PlainShader.hpp"
 
+namespace
+{
+    using Engine::Vector2;
+    struct PlainShaderContext
+    {
+        Vector2 vert_v0_texture_coord;
+        Vector2 vert_v1_texture_coord;
+        Vector2 vert_v2_texture_coord;
+    };
+}
+
 namespace Engine
 {
     namespace Rendering
@@ -11,22 +22,31 @@ namespace Engine
                 this->texture = std::move(texture);
             }
 
-            bool PlainShader::VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats)
+            size_t PlainShader::GetFragmentContextSize() const
             {
+                return sizeof(PlainShaderContext);
+            }
+
+            bool PlainShader::VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context)
+            {
+                auto ctx = static_cast<PlainShaderContext*>(context);
+
                 TransformVertexMVP(v0, mvp_mats);
                 TransformVertexMVP(v1, mvp_mats);
                 TransformVertexMVP(v2, mvp_mats);
 
-                vert_v0_texture_coord = v0.GetTextureCoords();
-                vert_v1_texture_coord = v1.GetTextureCoords();
-                vert_v2_texture_coord = v2.GetTextureCoords();
+                ctx->vert_v0_texture_coord = v0.GetTextureCoords();
+                ctx->vert_v1_texture_coord = v1.GetTextureCoords();
+                ctx->vert_v2_texture_coord = v2.GetTextureCoords();
 
                 return !IsBackface(v0.GetPosition(), v1.GetPosition(), v2.GetPosition());
             }
 
-            RGBColor PlainShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2)
+            RGBColor PlainShader::FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2, const void* context)
             {
-                Vector2 frag_texture_coord = PerspectiveCorrectInterpolate<Vector2>(vert_v0_texture_coord, vert_v1_texture_coord, vert_v2_texture_coord, triangle, barcoord0, barcoord1, barcoord2);
+                auto ctx = static_cast<const PlainShaderContext*>(context);
+
+                Vector2 frag_texture_coord = PerspectiveCorrectInterpolate<Vector2>(ctx->vert_v0_texture_coord, ctx->vert_v1_texture_coord, ctx->vert_v2_texture_coord, triangle, barcoord0, barcoord1, barcoord2);
 
                 RGBColor final_color = texture->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
                 final_color.BlendMultiply(color);

--- a/src/Engine/Rendering/Shaders/PlainShader.hpp
+++ b/src/Engine/Rendering/Shaders/PlainShader.hpp
@@ -21,14 +21,10 @@ namespace Engine
             private:
                 std::shared_ptr<Texture> texture;
 
-                // set by the vertex shader for the fragment shader
-                Vector2 vert_v0_texture_coord;
-                Vector2 vert_v1_texture_coord;
-                Vector2 vert_v2_texture_coord;
-
             public:
-                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) override;
-                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
+                virtual size_t GetFragmentContextSize() const override;
+                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context) override;
+                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2, const void* context) override;
 
                 void SetTexture(std::shared_ptr<Texture> texture);
             };

--- a/src/Engine/Rendering/Shaders/ShadedShader.cpp
+++ b/src/Engine/Rendering/Shaders/ShadedShader.cpp
@@ -70,7 +70,7 @@ namespace Engine
             bool ShadedShader::VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context)
             {
                 auto ctx = static_cast<ShadedShaderContext*>(context);
-                
+
                 TransformVertexModel(v0, mvp_mats);
                 TransformVertexModel(v1, mvp_mats);
                 TransformVertexModel(v2, mvp_mats);
@@ -90,7 +90,7 @@ namespace Engine
                     const Matrix4& light_view_mat       = light->GetViewMatrix().value().get();
                     const Matrix4& light_projection_mat = light->GetProjectionMatrix().value().get();
 
-                    MVPTransform light_mvp_mats = { light_unused_mat, light_unused_mat, light_view_mat, light_projection_mat };
+                    MVPTransform light_mvp_mats = {light_unused_mat, light_unused_mat, light_view_mat, light_projection_mat};
 
                     ctx->vert_v0_light[ctx->vert_lights_count] = v0;
                     ctx->vert_v1_light[ctx->vert_lights_count] = v1;
@@ -120,7 +120,8 @@ namespace Engine
 
                 Vector3 frag_position = PerspectiveCorrectInterpolate<Vector3>(ctx->vert_v0_model.GetPosition(), ctx->vert_v1_model.GetPosition(), ctx->vert_v2_model.GetPosition(), triangle, barcoord0, barcoord1, barcoord2);
 
-                Vector2 frag_texture_coord = PerspectiveCorrectInterpolate<Vector2>(ctx->vert_v0_model.GetTextureCoords(), ctx->vert_v1_model.GetTextureCoords(), ctx->vert_v2_model.GetTextureCoords(), triangle, barcoord0, barcoord1, barcoord2);
+                Vector2 frag_texture_coord =
+                    PerspectiveCorrectInterpolate<Vector2>(ctx->vert_v0_model.GetTextureCoords(), ctx->vert_v1_model.GetTextureCoords(), ctx->vert_v2_model.GetTextureCoords(), triangle, barcoord0, barcoord1, barcoord2);
 
                 Vector3 frag_normal = PerspectiveCorrectInterpolate<Vector3>(ctx->vert_v0_model.GetNormal(), ctx->vert_v1_model.GetNormal(), ctx->vert_v2_model.GetNormal(), triangle, barcoord0, barcoord1, barcoord2);
 
@@ -128,7 +129,8 @@ namespace Engine
                 {
                     Vector3 frag_tangent = PerspectiveCorrectInterpolate<Vector3>(ctx->vert_v0_model.GetTangent(), ctx->vert_v1_model.GetTangent(), ctx->vert_v2_model.GetTangent(), triangle, barcoord0, barcoord1, barcoord2);
 
-                    Vector3 frag_bitangent = PerspectiveCorrectInterpolate<Vector3>(ctx->vert_v0_model.GetBitangent(), ctx->vert_v1_model.GetBitangent(), ctx->vert_v2_model.GetBitangent(), triangle, barcoord0, barcoord1, barcoord2);
+                    Vector3 frag_bitangent =
+                        PerspectiveCorrectInterpolate<Vector3>(ctx->vert_v0_model.GetBitangent(), ctx->vert_v1_model.GetBitangent(), ctx->vert_v2_model.GetBitangent(), triangle, barcoord0, barcoord1, barcoord2);
 
                     RGBColor frag_normal_color = normal_map->GetColorFromTextureCoords(frag_texture_coord.x, frag_texture_coord.y);
 

--- a/src/Engine/Rendering/Shaders/ShadedShader.cpp
+++ b/src/Engine/Rendering/Shaders/ShadedShader.cpp
@@ -56,7 +56,7 @@ namespace Engine
 
                 vert_lights_count = 0;
 
-                for (std::shared_ptr<ILight> light : lighting_system->GetLights())
+                for (const std::shared_ptr<ILight>& light : lighting_system->GetLights())
                 {
                     if (!light->IsShadowCaster())
                         continue;

--- a/src/Engine/Rendering/Shaders/ShadedShader.hpp
+++ b/src/Engine/Rendering/Shaders/ShadedShader.hpp
@@ -33,17 +33,6 @@ namespace Engine
                 std::shared_ptr<Texture> texture;
                 std::shared_ptr<Texture> normal_map;
 
-                // set by the vertex shader for the fragment shader
-                Vertex vert_v0_model;
-                Vertex vert_v1_model;
-                Vertex vert_v2_model;
-
-                int vert_lights_count = 0;
-                // the same vertices but in light space, in multiple lights
-                Vertex vert_v0_light[10];
-                Vertex vert_v1_light[10];
-                Vertex vert_v2_light[10];
-
                 // a pointer here is prefered to avoid calling make_shared on every triangle
                 DepthBuffer* vert_light_depthbuffer[10];
 
@@ -56,8 +45,9 @@ namespace Engine
                 MaterialProperties material_properties;
 
             public:
-                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats) override;
-                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2) override;
+                virtual size_t GetFragmentContextSize() const override;
+                virtual bool VertexShader(Vertex& v0, Vertex& v1, Vertex& v2, const MVPTransform& mvp_mats, void* context) override;
+                virtual RGBColor FragmentShader(RGBColor color, const Triangle& triangle, float barcoord0, float barcoord1, float barcoord2, const void* context) override;
 
                 void SetLightingSystem(std::shared_ptr<LightingSystem> lighting_system);
 


### PR DESCRIPTION
Instead of passing context between vertex and fragment passes using member variables, instead pass context by using a type-erased context pointer.

I haven't done any actual parallelization, I'll leave that to you/someone else if they wish.

No significant performance difference can be seen between the 2 versions on my machine.